### PR TITLE
Make schema work with native firestore crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rs2js = "0.2"
-firebase-wasm = { git = "https://github.com/FredrikNoren/firebase-wasm-rs.git", rev = "3b871f6" }
-ambient_project = { git = "https://github.com/AmbientRun/Ambient.git", rev = "8839542" }
+ambient_project = { git = "https://github.com/AmbientRun/Ambient.git", rev = "5cba1c1d" }
 sha2 = "0.10.6"
 base16ct = { version = "0.2.0", features = ["alloc"] }
+serde = { version = "1", features = ["derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+firebase-wasm = { git = "https://github.com/FredrikNoren/firebase-wasm-rs.git", rev = "3b871f6" }
+rs2js = "0.2"
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+firestore = "0.32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub use ambient_project::Manifest;
+pub use ambient_project::{Manifest, Version};
 #[cfg(target_arch = "wasm32")]
 use rs2js::Rs2Js;
 
@@ -120,7 +120,7 @@ pub struct DbDeployment {
     pub ember_id: String,
     pub files: Vec<File>,
     pub manifest: Manifest,
-    pub ambient_version: String,
+    pub ambient_version: Version,
     #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,6 @@ pub trait DbCollection {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct DbEmber {
-    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
-    pub id: Option<String>,
     pub name: String,
     pub owner_id: String,
     #[cfg_attr(target_arch = "wasm32", raw)]
@@ -76,8 +74,6 @@ impl DbCollection for DbEmber {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct DbProfile {
-    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
-    pub id: Option<String>,
     pub username: String,
     #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
@@ -94,8 +90,6 @@ impl DbCollection for DbProfile {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct DbApiKey {
-    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
-    pub hash: Option<String>,
     #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
     pub user_id: String,
@@ -123,8 +117,6 @@ pub fn hash_api_key(api_key: &str) -> String {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct DbDeployment {
-    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
-    pub id: Option<String>,
     pub ember_id: String,
     pub files: Vec<File>,
     pub manifest: Manifest,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,18 @@
-use ambient_project::Manifest;
-use firebase_wasm::firestore::{DocumentReference, Timestamp};
+pub use ambient_project::Manifest;
+#[cfg(target_arch = "wasm32")]
 use rs2js::Rs2Js;
+
+#[cfg(target_arch = "wasm32")]
+use firebase_wasm::firestore::Timestamp;
+#[cfg(not(target_arch = "wasm32"))]
+use firestore::FirestoreTimestamp as Timestamp;
 
 #[derive(Debug, Clone, Copy)]
 pub enum DbCollections {
     Embers,
     Profiles,
     ApiKeys,
+    Deployments,
 }
 impl DbCollections {
     pub fn as_str(&self) -> &'static str {
@@ -14,44 +20,90 @@ impl DbCollections {
             DbCollections::Embers => "embers",
             DbCollections::Profiles => "profiles",
             DbCollections::ApiKeys => "api_keys",
+            DbCollections::Deployments => "deployments",
         }
     }
+    #[cfg(target_arch = "wasm32")]
     pub fn doc(&self, id: impl AsRef<str>) -> DocRef {
         DocRef(format!("{}/{}", self.as_str(), id.as_ref()))
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DocRef(String);
-impl From<DocRef> for DocumentReference {
+
+#[cfg(target_arch = "wasm32")]
+impl From<DocRef> for firebase_wasm::firestore::DocumentReference {
     fn from(value: DocRef) -> Self {
         let db = firebase_wasm::firestore::get_firestore();
         firebase_wasm::firestore::doc(db, &value.0).unwrap()
     }
 }
 
-#[derive(Rs2Js, Debug, Clone, PartialEq)]
+pub trait DbCollection {
+    const COLLECTION: DbCollections;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(target_arch = "wasm32", derive(Rs2Js))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct DbEmber {
+    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
+    pub id: Option<String>,
     pub name: String,
     pub owner_id: String,
-    #[raw]
+    #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
-    pub manifest: Manifest,
+    pub manifest: Option<Manifest>,
+    #[cfg_attr(not(target_arch = "wasm32"), serde(default))]
+    pub latest_deployment: String,
+    #[cfg_attr(not(target_arch = "wasm32"), serde(default))]
+    pub deployments: Vec<String>,
 }
 
-#[derive(Rs2Js, Debug, Clone, PartialEq)]
+impl DbCollection for DbEmber {
+    const COLLECTION: DbCollections = DbCollections::Embers;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(target_arch = "wasm32", derive(Rs2Js))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct DbProfile {
+    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
+    pub id: Option<String>,
     pub username: String,
-    #[raw]
+    #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
 }
 
-#[derive(Rs2Js, Debug, Clone, PartialEq)]
+impl DbCollection for DbProfile {
+    const COLLECTION: DbCollections = DbCollections::Profiles;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(target_arch = "wasm32", derive(Rs2Js))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct DbApiKey {
-    #[raw]
+    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
+    pub hash: Option<String>,
+    #[cfg_attr(target_arch = "wasm32", raw)]
     pub created: Timestamp,
     pub user_id: String,
     pub name: String,
+}
+
+impl DbCollection for DbApiKey {
+    const COLLECTION: DbCollections = DbCollections::ApiKeys;
 }
 
 pub fn hash_api_key(api_key: &str) -> String {
@@ -62,4 +114,34 @@ pub fn hash_api_key(api_key: &str) -> String {
     hasher.update(api_key);
     let hash = hasher.finalize();
     base16ct::lower::encode_string(&hash)
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(target_arch = "wasm32", derive(Rs2Js))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct DbDeployment {
+    #[cfg_attr(not(target_arch = "wasm32"), serde(alias = "_firestore_id"))]
+    pub id: Option<String>,
+    pub ember_id: String,
+    pub files: Vec<File>,
+    pub manifest: Manifest,
+    pub ambient_version: String,
+    #[cfg_attr(target_arch = "wasm32", raw)]
+    pub created: Timestamp,
+}
+
+impl DbCollection for DbDeployment {
+    const COLLECTION: DbCollections = DbCollections::Deployments;
+}
+
+pub type MD5Digest = [u8; 16];
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct File {
+    pub path: String,
+    pub size: usize,
+    pub md5: MD5Digest,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-pub use ambient_project::{Manifest, Version};
+pub use ::ambient_project;
+use ambient_project::{Manifest, Version};
 #[cfg(target_arch = "wasm32")]
 use rs2js::Rs2Js;
 


### PR DESCRIPTION
This currently uses `target_arch` to switch different features:
- `Rs2Js` - only for wasm32
- different `Timestamp` types
- derive for `serde::Serialize/Deserialize` - only for non-wasm32

Also adds `DbCollection` trait for easy development of `Db*` helpers.